### PR TITLE
Discoverable CLI, latest/info commands, and clearer errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,24 +38,36 @@ uv run selkokortti --help            # uv sets up the environment automatically
 | Command | What it does |
 | --- | --- |
 | `range yyyy.mm.dd yyyy.mm.dd` | Cards for an inclusive date range (most flexible). |
+| `latest [N]` | Cards for the N most recent available dates (default 7). |
 | `today` | Cards for today's date. |
 | `everything` | Cards for every available date. |
+| `info` | Show the dataset cache location and the available date range. |
 
-Shared options:
+Run `selkokortti --version` to print the version, or `selkokortti <command> --help`
+for a command's full options.
+
+Shared options (on the card-generating commands):
 
 - `--direction / -d` — `fi-en` (Finnish prompt → English, the default),
   `en-fi` (English prompt → Finnish, for active production practice), or
   `both` (one note, two linked cards in both directions).
 - `--output` — output filename (default `cards.apkg`).
+- `--deck-name` — name of the generated Anki deck (default `Selko`).
 - `--data-dir PATH` — use a local checkout of `selkouutiset-scrape-cleaned`
   instead of the auto-managed cache (skips all network access).
 - `--no-update` — reuse the cached dataset without refreshing it.
-- `--verbose / -v`, `--quiet / -q` — log verbosity.
+- `--verbose / -v`, `--quiet / -q` — log verbosity (`-v` also shows raw `git` output).
 
 ```bash
+selkokortti latest 7                                 # last 7 days of articles
 selkokortti range 2025.06.20 2025.06.23 -d both      # bidirectional cards
 selkokortti range 2025.06.20 2025.06.23 -d en-fi     # English → Finnish production
+selkokortti info                                     # what dates are available?
 ```
+
+If you ask for a date with no article (a weekend or a date that hasn't happened
+yet), `selkokortti` tells you so and points you at the most recent available date
+instead of failing cryptically.
 
 ![image](https://github.com/Selkouutiset-Archive/selkokortti/assets/53230903/07c80715-4d04-4012-8f06-6613824f9216)
 

--- a/selkokortti/cli.py
+++ b/selkokortti/cli.py
@@ -10,9 +10,25 @@ import colorlog
 import genanki
 import typer
 
+from . import __version__
 from .data import resolve_data_dir
 
-app = typer.Typer(help="Generate Anki flashcards from Andrew's Selkouutiset Archive.")
+APP_HELP = """Generate Anki flashcards from Andrew's Selkouutiset Archive (Finnish easy-news).
+
+The default direction is Finnish -> English. Use -d en-fi for English -> Finnish
+production practice, or -d both for bidirectional cards (one note, two cards).
+The news dataset is downloaded and kept up to date for you automatically.
+"""
+
+APP_EPILOG = """Examples:
+  selkokortti latest 7                       last 7 days of articles
+  selkokortti range 2025.06.20 2025.06.23    an inclusive date range
+  selkokortti range 2025.06.20 2025.06.23 -d both    bidirectional cards
+  selkokortti today -d en-fi                 today's article, English -> Finnish
+  selkokortti info                           show cache location + available dates
+"""
+
+app = typer.Typer(help=APP_HELP, epilog=APP_EPILOG, no_args_is_help=True)
 
 # Configure logger
 handler = colorlog.StreamHandler()
@@ -293,23 +309,68 @@ def find_date_range(directory_path: Path) -> Tuple[str, str]:
     return earliest_date.strftime("%Y.%m.%d"), latest_date.strftime("%Y.%m.%d")
 
 
+def available_dates(directory_path: Path) -> List[str]:
+    """Return every YYYY.MM.DD that has an article, sorted ascending."""
+    dates = []
+    for root, dirs, files in os.walk(str(directory_path)):
+        parts = root.split(os.sep)
+        if len(parts) >= 3:
+            try:
+                current = datetime(int(parts[-3]), int(parts[-2]), int(parts[-1]))
+            except ValueError:
+                continue
+            dates.append(current.strftime("%Y.%m.%d"))
+    return sorted(dates)
+
+
+def date_has_article(data_dir: Path, date_str: str) -> bool:
+    year, month, day = date_str.split(".")
+    return (Path(data_dir) / year / month / day).is_dir()
+
+
+def _latest_date_hint(data_dir: Path) -> Optional[str]:
+    try:
+        _, latest = find_date_range(data_dir)
+    except RuntimeError:
+        return None
+    return latest
+
+
 # --- Deck building --------------------------------------------------------
 
 def build_deck(
-    data_dir: Path, start_date: str, end_date: str, direction: Direction
+    data_dir: Path,
+    start_date: str,
+    end_date: str,
+    direction: Direction,
+    deck_name: str = "Selko",
+    warn_missing: bool = True,
 ) -> genanki.Deck:
     start = datetime.strptime(start_date, "%Y.%m.%d")
     end = datetime.strptime(end_date, "%Y.%m.%d")
+    if start > end:
+        raise typer.BadParameter(
+            f"start date {start_date} is after end date {end_date}."
+        )
 
     model = MODELS[direction]
-    deck = genanki.Deck(DECK_ID, "Selko")
+    deck = genanki.Deck(DECK_ID, deck_name)
 
     current_date = start
     note_count = 0
+    missing_count = 0
     while current_date <= end:
         date_str = current_date.strftime("%Y.%m.%d")
+        if not date_has_article(data_dir, date_str):
+            missing_count += 1
+            if warn_missing:
+                logger.warning("No article published for %s (skipped).", date_str)
+            else:
+                logger.debug("No article for %s (skipped).", date_str)
+            current_date += timedelta(days=1)
+            continue
         pairs = process_translations_for_date(data_dir, date_str)
-        deck_label = f"Selko :: {date_str}"
+        deck_label = f"{deck_name} :: {date_str}"
         for finnish, english in pairs:
             deck.add_note(
                 genanki.Note(model=model, fields=[deck_label, finnish, english])
@@ -319,7 +380,20 @@ def build_deck(
         current_date += timedelta(days=1)
 
     if note_count == 0:
-        logger.warning("No data found for %s .. %s", start_date, end_date)
+        logger.error(
+            "No flashcards generated: no articles found for %s .. %s.",
+            start_date,
+            end_date,
+        )
+        latest = _latest_date_hint(data_dir)
+        if latest:
+            logger.error(
+                "The most recent available date is %s — try: "
+                "selkokortti range %s %s",
+                latest,
+                latest,
+                latest,
+            )
         raise typer.Exit(code=1)
 
     logger.info(
@@ -349,6 +423,9 @@ def set_logging(quiet: bool, verbose: bool):
 # --- Shared option helpers ------------------------------------------------
 
 OutputOpt = typer.Option("cards.apkg", help="Output Anki file name.")
+DeckNameOpt = typer.Option(
+    "Selko", "--deck-name", help="Name of the generated Anki deck."
+)
 DirectionOpt = typer.Option(
     Direction.fi_en,
     "--direction",
@@ -378,10 +455,31 @@ QuietOpt = typer.Option(
 
 # --- Commands -------------------------------------------------------------
 
-@app.command()
+def _version_callback(value: bool):
+    if value:
+        typer.echo(f"selkokortti {__version__}")
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        "-V",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show the selkokortti version and exit.",
+    ),
+):
+    """Generate Anki flashcards from Andrew's Selkouutiset Archive."""
+
+
+@app.command(epilog="Example: selkokortti today -d both")
 def today(
     output: str = OutputOpt,
     direction: Direction = DirectionOpt,
+    deck_name: str = DeckNameOpt,
     data_dir: Optional[str] = DataDirOpt,
     no_update: bool = NoUpdateOpt,
     verbose: bool = VerboseOpt,
@@ -391,14 +489,15 @@ def today(
     set_logging(quiet, verbose)
     resolved = resolve_data_dir(data_dir, no_update)
     today_date = datetime.now().strftime("%Y.%m.%d")
-    deck = build_deck(resolved, today_date, today_date, direction)
+    deck = build_deck(resolved, today_date, today_date, direction, deck_name)
     write_deck(deck, output)
 
 
-@app.command()
+@app.command(epilog="Example: selkokortti everything --output all.apkg")
 def everything(
     output: str = OutputOpt,
     direction: Direction = DirectionOpt,
+    deck_name: str = DeckNameOpt,
     data_dir: Optional[str] = DataDirOpt,
     no_update: bool = NoUpdateOpt,
     verbose: bool = VerboseOpt,
@@ -408,11 +507,15 @@ def everything(
     set_logging(quiet, verbose)
     resolved = resolve_data_dir(data_dir, no_update)
     start_date, end_date = find_date_range(resolved)
-    deck = build_deck(resolved, start_date, end_date, direction)
+    # Gaps (weekends, holidays) across the full archive are expected, so don't
+    # warn per missing date here.
+    deck = build_deck(
+        resolved, start_date, end_date, direction, deck_name, warn_missing=False
+    )
     write_deck(deck, output)
 
 
-@app.command()
+@app.command(epilog="Example: selkokortti range 2025.06.20 2025.06.23 -d both")
 def range(
     start_date: str = typer.Argument(
         ..., formats=["%Y.%m.%d"], help="Start date in yyyy.mm.dd format"
@@ -422,6 +525,7 @@ def range(
     ),
     output: str = OutputOpt,
     direction: Direction = DirectionOpt,
+    deck_name: str = DeckNameOpt,
     data_dir: Optional[str] = DataDirOpt,
     no_update: bool = NoUpdateOpt,
     verbose: bool = VerboseOpt,
@@ -430,8 +534,55 @@ def range(
     """Generate flashcards for an inclusive date range."""
     set_logging(quiet, verbose)
     resolved = resolve_data_dir(data_dir, no_update)
-    deck = build_deck(resolved, start_date, end_date, direction)
+    deck = build_deck(resolved, start_date, end_date, direction, deck_name)
     write_deck(deck, output)
+
+
+@app.command(epilog="Example: selkokortti latest 7 -d both")
+def latest(
+    count: int = typer.Argument(
+        7, min=1, help="Number of most recent available dates to include."
+    ),
+    output: str = OutputOpt,
+    direction: Direction = DirectionOpt,
+    deck_name: str = DeckNameOpt,
+    data_dir: Optional[str] = DataDirOpt,
+    no_update: bool = NoUpdateOpt,
+    verbose: bool = VerboseOpt,
+    quiet: bool = QuietOpt,
+):
+    """Generate flashcards for the N most recent available dates."""
+    set_logging(quiet, verbose)
+    resolved = resolve_data_dir(data_dir, no_update)
+    dates = available_dates(resolved)
+    if not dates:
+        logger.error("No articles found under %s.", resolved)
+        raise typer.Exit(code=1)
+    chosen = dates[-count:]
+    # chosen are all existing dates; gaps within the window are expected.
+    deck = build_deck(
+        resolved, chosen[0], chosen[-1], direction, deck_name, warn_missing=False
+    )
+    write_deck(deck, output)
+
+
+@app.command()
+def info(
+    data_dir: Optional[str] = DataDirOpt,
+    no_update: bool = NoUpdateOpt,
+    verbose: bool = VerboseOpt,
+    quiet: bool = QuietOpt,
+):
+    """Show the dataset cache location and the available date range."""
+    set_logging(quiet, verbose)
+    resolved = resolve_data_dir(data_dir, no_update)
+    typer.echo(f"selkokortti {__version__}")
+    typer.echo(f"Data directory: {resolved}")
+    dates = available_dates(resolved)
+    if not dates:
+        typer.echo("Available dates: none (dataset is empty)")
+        return
+    typer.echo(f"Available dates: {dates[0]} .. {dates[-1]} ({len(dates)} days)")
 
 
 if __name__ == "__main__":

--- a/selkokortti/data.py
+++ b/selkokortti/data.py
@@ -27,11 +27,20 @@ def _run_git(args, cwd=None):
             "local checkout of selkouutiset-scrape-cleaned."
         )
     logger.debug("git %s (cwd=%s)", " ".join(args), cwd)
-    subprocess.run(
+    # Keep git's own chatter ("remote: ...", "HEAD is now at ...") out of the
+    # way unless the user asked for verbose logging; on failure we surface the
+    # captured stderr so the error is still legible.
+    verbose = logger.isEnabledFor(logging.DEBUG)
+    result = subprocess.run(
         ["git", *args],
         cwd=str(cwd) if cwd else None,
-        check=True,
+        capture_output=not verbose,
+        text=True,
     )
+    if result.returncode != 0:
+        detail = (result.stderr or "").strip() if not verbose else ""
+        suffix = f"\n{detail}" if detail else ""
+        raise RuntimeError(f"`git {' '.join(args)}` failed.{suffix}")
 
 
 def default_cache_dir() -> Path:
@@ -58,17 +67,24 @@ def resolve_data_dir(data_dir=None, no_update: bool = False) -> Path:
         path.parent.mkdir(parents=True, exist_ok=True)
         if path.exists():
             shutil.rmtree(path)
-        _run_git(
-            [
-                "clone",
-                "--depth",
-                "1",
-                "--branch",
-                DATA_REPO_BRANCH,
-                DATA_REPO_URL,
-                str(path),
-            ]
-        )
+        try:
+            _run_git(
+                [
+                    "clone",
+                    "--depth",
+                    "1",
+                    "--branch",
+                    DATA_REPO_BRANCH,
+                    DATA_REPO_URL,
+                    str(path),
+                ]
+            )
+        except RuntimeError as exc:
+            raise RuntimeError(
+                "Failed to download the Selkouutiset dataset. Check your network "
+                "connection, or pass --data-dir pointing at a local checkout of "
+                f"selkouutiset-scrape-cleaned.\n{exc}"
+            ) from exc
     elif not no_update:
         logger.info("Refreshing Selkouutiset dataset in %s ...", path)
         _run_git(["fetch", "--depth", "1", "origin", DATA_REPO_BRANCH], cwd=path)


### PR DESCRIPTION
## Summary

Follow-up to the `uv` packaging work, driven by real-world use. Two problems showed up: the top-level `--help` was bare (all useful flags lived on subcommands, so bidirectional cards weren't discoverable), and asking for a date with no article printed two scary `ERROR: File not found` lines plus raw `git` chatter.

## What changed

**Discoverability**
- App callback with a descriptive help blurb + examples epilog → `selkokortti --help` now explains directions (incl. `-d both`) and shows copy-pasteable examples.
- Global `--version / -V`; per-command example epilogs.

**New commands / options**
- `latest [N]` — cards for the N most recent available dates (default 7).
- `info` — prints the dataset cache location and available date range.
- `--deck-name` — override the Anki deck name (default `Selko`).

**Clearer errors**
- "No article that day" (a normal weekend/future gap) → one `WARNING` per requested date instead of two red `File not found` ERRORs. `everything` keeps its expected archive gaps at DEBUG (no flood).
- When nothing is generated: report the most recent available date + a ready-to-run `range` command, exit non-zero. `start > end` → `BadParameter`.
- Quiet git by default: `remote:` / `HEAD is now at` chatter suppressed unless `-v`; git failures surface captured stderr; clone failures add a network/`--data-dir` hint.

## Testing
- `selkokortti --help` shows `--version`, all 5 commands, and the examples epilog; `--version` prints `selkokortti 0.2.0`.
- `range 2025.06.23 2025.06.25` → one WARNING per missing date, no `File not found`, still builds the present date.
- `today` with no article → actionable error naming latest date + suggested `range`, exit 1.
- `latest 3` → 101 notes across the 3 newest dates; `everything` → 0 warning flood.
- `--deck-name "Finnish News"` → confirmed via sqlite (`col.decks` JSON).
- Normal fetch → no git chatter; `-v` → git output returns.