### PR TITLE
Per-month subdecks, date tags, and source links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ On first run it clones the [Selkouutiset data
 repo](https://github.com/hiAndrewQuinn/selkouutiset-scrape-cleaned) into your
 user cache directory, and refreshes it on every subsequent run. A file called
 `cards.apkg` appears in your current directory — import it into Anki and start
-going through the new `Selko` deck.
+going through the new `Selko` deck. Cards are organised into per-month subdecks
+(`Selko::2025::06`), tagged by date (`selko`, `2025-06-23`), and each card links
+back to the original article in the archive.
 
 You can also run it without installing, or hack on it locally:
 

--- a/selkokortti/cli.py
+++ b/selkokortti/cli.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import re
+import zlib
 from datetime import datetime, timedelta
 from enum import Enum
 from pathlib import Path
@@ -143,6 +144,7 @@ _FI_BACK = """
 </div>
 <hr />
 <aside>
+    <p>{{Source}}</p>
     <p>Proudly brought to you by <a href="https://hiandrewquinn.github.io/selkouutiset-archive/">Andrew's Selkouutiset Archive</a>.</p>
     <p>Find this useful? <a href="https://www.linkedin.com/in/heiandrewquinn/">Add Andrew on LinkedIn</a>!</p>
     <p>Spotted a bug? <a href="https://github.com/Selkouutiset-Archive/selkokortti/issues">Let us know on Github!</a></p>
@@ -176,6 +178,7 @@ _EN_BACK = """
 </div>
 <hr />
 <aside>
+    <p>{{Source}}</p>
     <p>Proudly brought to you by <a href="https://hiandrewquinn.github.io/selkouutiset-archive/">Andrew's Selkouutiset Archive</a>.</p>
     <p>Find this useful? <a href="https://www.linkedin.com/in/heiandrewquinn/">Add Andrew on LinkedIn</a>!</p>
     <p>Spotted a bug? <a href="https://github.com/Selkouutiset-Archive/selkokortti/issues">Let us know on Github!</a></p>
@@ -267,13 +270,21 @@ _EN_BACK_TYPED = """
 </div>
 <hr />
 <aside>
+    <p>{{Source}}</p>
     <p>Proudly brought to you by <a href="https://hiandrewquinn.github.io/selkouutiset-archive/">Andrew's Selkouutiset Archive</a>.</p>
     <p>Find this useful? <a href="https://www.linkedin.com/in/heiandrewquinn/">Add Andrew on LinkedIn</a>!</p>
     <p>Spotted a bug? <a href="https://github.com/Selkouutiset-Archive/selkokortti/issues">Let us know on Github!</a></p>
 </aside>
 """
 
-_FIELDS = [{"name": "Deck"}, {"name": "Finnish"}, {"name": "English"}]
+_FIELDS = [
+    {"name": "Deck"},
+    {"name": "Finnish"},
+    {"name": "English"},
+    {"name": "Source"},
+]
+
+ARCHIVE_BASE_URL = "https://hiandrewquinn.github.io/selkouutiset-archive"
 
 _TEMPLATE_FI_EN = {"name": "Finnish to English", "qfmt": _FI_FRONT, "afmt": _FI_BACK}
 _TEMPLATE_EN_FI = {"name": "English to Finnish", "qfmt": _EN_FRONT, "afmt": _EN_BACK}
@@ -502,7 +513,7 @@ def build_deck(
     deck_name: str = "Selko",
     warn_missing: bool = True,
     typed: bool = True,
-) -> genanki.Deck:
+) -> List[genanki.Deck]:
     start = datetime.strptime(start_date, "%Y.%m.%d")
     end = datetime.strptime(end_date, "%Y.%m.%d")
     if start > end:
@@ -511,7 +522,17 @@ def build_deck(
         )
 
     model = get_model(direction, typed)
-    deck = genanki.Deck(DECK_ID, deck_name)
+
+    # One subdeck per month, e.g. "Selko::2025::06", so the cards stay organised
+    # in Anki. Deck IDs are derived deterministically from the name so re-imports
+    # merge into the same decks.
+    decks = {}
+
+    def _month_deck(year: str, month: str) -> genanki.Deck:
+        name = f"{deck_name}::{year}::{month}"
+        if name not in decks:
+            decks[name] = genanki.Deck(_deck_id(name), name)
+        return decks[name]
 
     current_date = start
     note_count = 0
@@ -527,8 +548,12 @@ def build_deck(
                 logger.debug("No article for %s (skipped).", date_str)
             current_date += timedelta(days=1)
             continue
-        pairs = process_translations_for_date(data_dir, date_str)
+        year, month, _day = date_str.split(".")
+        deck = _month_deck(year, month)
         deck_label = f"{deck_name} :: {date_str}"
+        source = _source_link(date_str)
+        tags = ["selko", current_date.strftime("%Y-%m-%d")]
+        pairs = process_translations_for_date(data_dir, date_str)
         for finnish, english in pairs:
             # Stable GUID keyed on (direction, Finnish) so re-runs update rather
             # than duplicate, and identical sentences dedup within the build.
@@ -539,7 +564,13 @@ def build_deck(
             deck.add_note(
                 genanki.Note(
                     model=model,
-                    fields=[deck_label, render_text(finnish), render_text(english)],
+                    fields=[
+                        deck_label,
+                        render_text(finnish),
+                        render_text(english),
+                        source,
+                    ],
+                    tags=tags,
                     guid=guid,
                 )
             )
@@ -565,17 +596,29 @@ def build_deck(
         raise typer.Exit(code=1)
 
     logger.info(
-        "Built %d notes (%s) for %s .. %s",
+        "Built %d notes (%s) across %d subdeck(s) for %s .. %s",
         note_count,
         direction.value,
+        len(decks),
         start_date,
         end_date,
     )
-    return deck
+    return list(decks.values())
 
 
-def write_deck(deck: genanki.Deck, output_file: str) -> None:
-    genanki.Package(deck).write_to_file(output_file)
+def _deck_id(name: str) -> int:
+    # Deterministic, stable, positive 31-bit id derived from the deck name.
+    return zlib.crc32(name.encode("utf-8")) & 0x7FFFFFFF
+
+
+def _source_link(date_str: str) -> str:
+    year, month, day = date_str.split(".")
+    url = f"{ARCHIVE_BASE_URL}/{year}/{month}/{day}/"
+    return f'<a href="{url}">Read the full article ({date_str})</a>'
+
+
+def write_deck(decks, output_file: str) -> None:
+    genanki.Package(decks).write_to_file(output_file)
     logger.info("Wrote %s", output_file)
 
 


### PR DESCRIPTION
## Summary
Organisational/UX improvements to the generated deck.

- **Subdecks**: one deck per month (`Selko::2025::06`) with deterministic crc32-derived IDs so re-imports merge. `build_deck` returns a list of decks; `write_deck` packages them.
- **Tags**: every note tagged `["selko", "YYYY-MM-DD"]`.
- **Source link**: new `Source` field renders "Read the full article (DATE)" on the back, linking to the per-date archive page (`…/selkouutiset-archive/YYYY/MM/DD/`, verified 200).

## Testing
- `range 2025.05.30 2025.06.02 -d both` → 2 subdecks (`Selko::2025::05`, `Selko::2025::06`); notes tagged `selko 2025-05-30`; fields now number 4 with the source link present. Verified via sqlite (`col.decks`, `notes.tags`, `notes.flds`).